### PR TITLE
Always convert return values to tibble

### DIFF
--- a/R/forecast.R
+++ b/R/forecast.R
@@ -75,9 +75,9 @@ forecast3day = function(location,
           stringsAsFactors = FALSE
     )
   })
-  
-  dplyr::bind_rows(df)
-} 
+
+  dplyr::tbl_df(dplyr::bind_rows(df))
+}
 
 #' Forecast for the next 10 days.
 #' 
@@ -157,5 +157,5 @@ forecast10day = function(location,
     )
   })
 
-  dplyr::bind_rows(df)
+  dplyr::tbl_df(dplyr::bind_rows(df))
 }

--- a/R/geolookup.R
+++ b/R/geolookup.R
@@ -75,8 +75,7 @@ geolookup = function(location,
         stringsAsFactors = FALSE
     )
   })
-  pws_df = dplyr::bind_rows(pws_df)
 
-  geo_df = dplyr::rbind_list(airport_df, pws_df)
+  geo_df = dplyr::tbl_df(dplyr::bind_rows(airport_df, pws_df))
   dplyr::filter(geo_df, !is.na(geo_df$lat) | !is.na(geo_df$lon))
 }

--- a/R/history.R
+++ b/R/history.R
@@ -223,9 +223,9 @@ history_range = function(location,
 
   history_list = 
   lapply(date_range, function(x) {
-    if(!is.null(limit) &
-      length(date_range) > limit & 
-      which(x == date_range) > 0 & 
+    if(!is.null(limit) &&
+      length(date_range) > limit && 
+      which(x == date_range) > 0 && 
       which(x == date_range) %% limit == 0) {
 
       if(message) {

--- a/R/history.R
+++ b/R/history.R
@@ -72,7 +72,7 @@ history = function(location,
   })
 
   encode_NA(
-    dplyr::bind_rows(lapply(df, data.frame, stringsAsFactors = FALSE))
+    dplyr::bind_rows(lapply(df, dplyr::as_tibble))
   )
 }
 
@@ -245,5 +245,5 @@ history_range = function(location,
     return(history_list)
   }
 
-  dplyr::bind_rows(history_list)
+  dplyr::tbl_df(dplyr::bind_rows(history_list))
 }

--- a/R/hourly.R
+++ b/R/hourly.R
@@ -40,7 +40,7 @@ hourly = function(location,
 
   units = ifelse(use_metric, "metric", "english")    
   df = lapply(hourly_forecast, function(x) {
-    data.frame(
+    dplyr::tibble(
          date = as.POSIXct(as.numeric(x$FCTTIME$epoch),
           origin = "1970-01-01", tz = strsplit(x$FCTTIME$pretty, split = " ")[[1]][3]),
          temp = as.numeric(x$temp[[units]]),
@@ -56,9 +56,8 @@ hourly = function(location,
          rain = as.numeric(x$qpf[[units]]),
          snow = as.numeric(x$snow[[units]]),
          pop = as.numeric(x$pop),
-         mslp = as.numeric(x$mslp[[units]]),
-          stringsAsFactors = FALSE
-         )
+         mslp = as.numeric(x$mslp[[units]])
+    )
   })
 
   encode_NA(
@@ -108,7 +107,7 @@ hourly10day = function(location,
 
   units = ifelse(use_metric, "metric", "english")    
   df = lapply(hourly_forecast, function(x){
-    data.frame(
+    dplyr::tibble(
          date = as.POSIXct(as.numeric(x$FCTTIME$epoch),
           origin = "1970-01-01", tz = strsplit(x$FCTTIME$pretty, split = " ")[[1]][3]),
          temp = as.numeric(x$temp[[units]]),
@@ -124,9 +123,8 @@ hourly10day = function(location,
          rain = as.numeric(x$qpf[[units]]),
          snow = as.numeric(x$snow[[units]]),
          pop = as.numeric(x$pop),
-         mslp = as.numeric(x$mslp[[units]]),
-          stringsAsFactors = FALSE
-         )
+         mslp = as.numeric(x$mslp[[units]])
+    )
   })
 
   encode_NA(

--- a/R/tide.R
+++ b/R/tide.R
@@ -53,7 +53,7 @@ tide = function(location,
     )
   })
 
-  tide_df = dplyr::bind_rows(df)
+  tide_df = dplyr::tbl_df(dplyr::bind_rows(df))
   dplyr::filter(tide_df, !is.na(tide_df$height))
 }
 
@@ -112,5 +112,5 @@ rawtide = function(location,
     )
   })
 
-  dplyr::bind_rows(df)
+  dplyr::tbl_df(dplyr::bind_rows(df))
 }


### PR DESCRIPTION
dplyr >= 0.7 doesn't forcibly convert to tibble anymore after `bind_rows()`. Also replaced one instance of the deprecated `rbind_list()` by `bind_rows()`.