### PR TITLE
Remove extra records on days when DST goes into effect

### DIFF
--- a/R/history.R
+++ b/R/history.R
@@ -100,6 +100,12 @@ history <- function(location,
     )
   })
   df <- encode_NA(dplyr::bind_rows(lapply(df, dplyr::as_tibble)))
+  testdate <- paste0(df$year,df$mon,df$mday)
+  if (sum(testdate!=date)>0) {
+    print(paste0("dropping ",sum(testdate!=date),
+                   " returned observations not on ", date))
+    df <- df[testdate==date,]
+  }
   if (length(df) > 0) {
     df$date <- dst_POSIXct(y=df$year,m=df$mon,d=df$mday,
                            hr=df$hour,mn=df$min,sec="00",tz=df$tz)


### PR DESCRIPTION
For some reason, wunderground.com returns extra records from the subsequent day, for some locations on some days when Daylight Saving time goes into effect.  Previously, history() would return some extra records with a timestamp from the day after the impacted day along with the requested records.  history_range() would return duplicate records, because the additional records would also be returned for the following (correct) day.  This does not happen for all locations all years.  It appears that pws locations that generate roughly 250 records per day were unaffected, I don't know the exact details.

Archived datasets in uses which rely on observations being unique should be checked if the implied level of inaccuracy is bothersome to you.  Simply checking for multiple observations taken at the same time is not sufficient, some locations have multiple different measurements at the same time, and may represent two streams of measurements merged - check the Paris airports.  This may or may not matter to you depending on what you are doing with the data.  Be aware of this potential issue for roughly **one hour of data per year**.

This fix strips records which are not from the requested day at the history() level, so history_range() will also behave more desirably in this edge case.